### PR TITLE
use 'path' property to get full path for ffmpeg

### DIFF
--- a/lang-learner.lua
+++ b/lang-learner.lua
@@ -120,7 +120,7 @@ end
 function do_store(tag)
   local sub = get_sub()
   if sub == nil then return; end
-  sub['source'] = mp.get_property('filename')
+  sub['source'] = mp.get_property('path')
 
   local dir = o['store_dir']
   if dir == "" or dir == nil then return; end


### PR DESCRIPTION
This patch fixes audio extraction when `mpv` invoked from the file browser or in general file is not in current directory of `mpv`.